### PR TITLE
Fix to not fail when API is not returning data

### DIFF
--- a/bin/porch-pirate
+++ b/bin/porch-pirate
@@ -143,7 +143,7 @@ if(arguments.s):
                 print(f"\n{YELLOW}[*]{END} Querying workspace ID {CYAN}{w}{END}\n")
                 workspace = json.loads(porchpirate.workspace(w))
                 collections = json.loads(porchpirate.collections(w))
-                for collection in collections['data']:
+                for collection in collections.get('data', []):
                     requests = collection['requests']
                     for r in requests:
                         request_data = json.loads(porchpirate.request(r['id']))
@@ -172,7 +172,7 @@ if(arguments.s):
                 print(f"\n{YELLOW}[*]{END} Querying workspace ID {CYAN}{w}{END}\n")
                 workspace = json.loads(porchpirate.workspace(w))
                 collections = json.loads(porchpirate.collections(w))
-                for collection in collections['data']:
+                for collection in collections.get('data', []):
                     requests = collection['requests']
                     try:
                         for r in requests:
@@ -232,7 +232,7 @@ if(arguments.w):
         porchpirate = porchpirate(proxy=proxyconfig)
         collections = json.loads(porchpirate.collections(arguments.w))
         try:
-            for collection in collections['data']:
+            for collection in collections.get('data', []):
                 requests = collection['requests']
                 for r in requests:
                     request_data = json.loads(porchpirate.request(r['id']))
@@ -250,7 +250,7 @@ if(arguments.w):
         porchpirate = porchpirate(proxy=proxyconfig)
         collections = json.loads(porchpirate.collections(arguments.w))
         try:
-            for collection in collections['data']:
+            for collection in collections.get('data', []):
                 requests = collection['requests']
                 for r in requests:
                     request_data = json.loads(porchpirate.request(r['id']))
@@ -277,7 +277,7 @@ if(arguments.w):
         porchpirate = porchpirate(proxy=proxyconfig)
         collections = json.loads(porchpirate.collections(arguments.w))
         try:
-            for collection in collections['data']:
+            for collection in collections.get('data', []):
                 requests = collection['requests']
                 try:
                     for request in requests:

--- a/porchpirate/porchpirate.py
+++ b/porchpirate/porchpirate.py
@@ -137,7 +137,7 @@ class porchpirate():
         print(f"{BOLD} - Last updated: {END}{CYAN}{collection_updated_at}{END}{END}")
 
     def _show_formatted_collections(self, workspace_collections):
-        for collection in workspace_collections['data']:
+        for collection in workspace_collections.get('data', []):
             collection_id = collection['id']
             collection_name = collection['name']
             collection_requests = collection['requests']
@@ -199,7 +199,7 @@ class porchpirate():
         print(f"{BOLD}- Friendly: {END}{CYAN}{profile['info']['friendly']}{END}")
         print(f"{BOLD}- User ID: {END}{YELLOW}{profile['entity_id']}{END}\n")
         print(f"{BOLD}Collections:{END}")
-        for entity in collections['data']['collections']:
+        for entity in collections.get('data', {}).get('collections', []):
             entity_id = entity['entityId']
             entity_name = entity['name']
             print(f" - {YELLOW}{entity_id}{END}{END} ({entity_name}{END})")
@@ -219,7 +219,7 @@ class porchpirate():
         print(f"{BOLD}- Friendly: {END}{CYAN}{profile['info']['friendly']}{END}")
         print(f"{BOLD}- Team ID: {END}{YELLOW}{profile['entity_id']}{END}\n")
         print(f"{BOLD}Collections:{END}")
-        for entity in collections['data']['collections']:
+        for entity in collections.get('data', {}).get('collections', []):
             entity_id = entity['entityId']
             entity_name = entity['name']
             print(f" - {YELLOW}{entity_id}{END}{END} ({entity_name}{END})")

--- a/porchpirate/porchpirate.py
+++ b/porchpirate/porchpirate.py
@@ -235,7 +235,7 @@ class porchpirate():
             print(f" - {YELLOW}{user_name}{END}{END} ({user_id}{END})")
 
     def search(self, term, page=None, indice=None, limit=100):
-        if limit is not 100:
+        if limit != 100:
             limit = int(limit)
         if page is not None:
             page = int(page)*limit


### PR DESCRIPTION
It happens that API doesn't return data and then `collections` variable at different places and you get errors like this:
```
Traceback (most recent call last):                                                                                                                                                                                 File "/usr/bin/porch-pirate", line 146, in <module>                                                                                                                                                                for collection in collections['data']:                                                                                                                                                                                             ~~~~~~~~~~~^^^^^^^^                                                                                                                                                                        
```

Suggested fix uses `get` method to safely return an empty array allowing porch-pirate to continue.

There's also fix for syntax warning generated in newer Python versions when comparing for integer value using `is` syntax.

Feel free to reject or change, cool tool otherwise.