### PR TITLE
Fixed empty data traversal when dump argument is set

### DIFF
--- a/bin/porch-pirate
+++ b/bin/porch-pirate
@@ -130,14 +130,15 @@ if(arguments.s):
 
     if(arguments.dump):
         workspaces = []
-        for result in search['data']:
-            try:
-                workspace = result['document']['workspaces']
-                for w in workspace:
-                    if w['id'] not in workspaces:
-                        workspaces.append(w['id'])
-            except:
-                pass
+        if 'data' in search:
+            for result in search['data']:
+                try:
+                    workspace = result['document']['workspaces']
+                    for w in workspace:
+                        if w['id'] not in workspaces:
+                            workspaces.append(w['id'])
+                except:
+                    pass
         for w in workspaces:
             try:
                 print(f"\n{YELLOW}[*]{END} Querying workspace ID {CYAN}{w}{END}\n")


### PR DESCRIPTION
upon using --dump argument it would give the result

line 133, in <module>
    for result in search['data']:
                  ~~~~~~^^^^^^^^
KeyError: 'data'

Fixed that by adding the condition.